### PR TITLE
Check for database changes in the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,11 @@ This app can browse notes from an SQLite database which was edited using the Bea
 
 ## Sync
 
-There is currently no sync functionality built into Eisbär. To sync data between the android phone and the desktop app, you will need to update the sqlite database file either manually, or using a third-party solution such as [Syncthing](https://syncthing.net).
+There is currently no sync functionality built into Eisbär. To sync data between the android phone and the desktop app, you will need to update the sqlite database file either manually, using a third-party solution such as [Syncthing](https://syncthing.net), or by copying it to Google Drive.
 
-Every time the app process is started, it copies the sqlite file into the private app data folder. If the sqlite file was updated, you need to stop the Eisbär app process, e.g. by removing it from the recent apps screen. Then start Eisbär again and the app will read the updated sqlite file.
+On startup and then every 10 seconds, Eisbär checks the database file for changes, i.e., different size or modification date. If changes are detected, the external database file is copied into the private app data directory and the internal database is reopened. In the note list view, you can also use swipe-to-refresh to tell the document provider which provides the external database file, e.g. Google Drive, to refresh / download the file.
 
-Working with an external sqlite database file appears to not be possible in android. Android apps can only open sqlite databases located in a specific folder in the private app data directory. That's why Eisbär copies the sqlite database when the app is launched. This may take a few seconds if you have a lot of notes.
-
-Reacting to database changes will need some work or may change to some kind of online sync in the future.
+Working with an external sqlite database file appears to not be possible in android. Android apps can only open sqlite databases located in a specific folder in the private app data directory. That's why Eisbär copies the sqlite database when it detects changes to the external file. This may take a few seconds if you have a lot of notes.
 
 ## Why requery and not Room?
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ This app can browse notes from an SQLite database which was edited using the Bea
 * View notes
 * Search notes
 * Rendered Markdown
+* List of tags
 
 ### Not now / Maybe later
 
-* List of tags
 * Support for images and attachments  
-* Some kind of sync
 
 ### Probably never
 

--- a/app/src/main/java/de/theess/eisbaer/EisbaerApplication.kt
+++ b/app/src/main/java/de/theess/eisbaer/EisbaerApplication.kt
@@ -24,6 +24,6 @@ class EisbaerApplication : Application() {
 
     companion object {
         const val PREF_DATABASE_URI: String = "database_uri"
-        const val PREF_DATABASE_FILE_SIZE: String = "database_file_size"
+        const val PREF_DATABASE_HASH: String = "database_hash"
     }
 }

--- a/app/src/main/java/de/theess/eisbaer/EisbaerApplication.kt
+++ b/app/src/main/java/de/theess/eisbaer/EisbaerApplication.kt
@@ -24,5 +24,6 @@ class EisbaerApplication : Application() {
 
     companion object {
         const val PREF_DATABASE_URI: String = "database_uri"
+        const val PREF_DATABASE_FILE_SIZE: String = "database_file_size"
     }
 }

--- a/app/src/main/java/de/theess/eisbaer/MainActivity.kt
+++ b/app/src/main/java/de/theess/eisbaer/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.navigation.ui.onNavDestinationSelected
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.navigation.NavigationView
+import com.google.android.material.snackbar.Snackbar
 import de.theess.eisbaer.data.TagRepository
 import de.theess.eisbaer.ui.note.NoteViewFragmentDirections
 import kotlinx.android.synthetic.main.activity_main.*
@@ -58,6 +59,14 @@ class MainActivity : AppCompatActivity() {
                         addTagMenuItem(navView.menu, tag)
                     }
             })
+
+        // Show messages from the database in the snackbar.
+        (application as EisbaerApplication).database.status.observe(this, Observer { message ->
+            if (message != null && !message.isEmpty()) {
+                Snackbar.make(drawerLayout, message, Snackbar.LENGTH_LONG)
+                    .show()
+            }
+        })
     }
 
     /**

--- a/app/src/main/java/de/theess/eisbaer/data/AbstractRepository.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/AbstractRepository.kt
@@ -1,0 +1,55 @@
+package de.theess.eisbaer.data
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import timber.log.Timber
+import java.util.*
+
+/**
+ * Base class for repositories. Provides support for converting database results to LiveData
+ * objects, and updating the LiveDatas when the database changes.
+ */
+open class AbstractRepository(database: Database) : DatabaseListener {
+    init {
+        database.addListener(this)
+    }
+
+    /**
+     * Map of LiveData to value function.
+     *
+     * We collect all LiveDatas in this map. When the database changes, the livedatas will be
+     * updated using the value function.
+     */
+    private val liveDataMap: MutableMap<MutableLiveData<Any>, () -> Any?> =
+        WeakHashMap<MutableLiveData<Any>, () -> Any?>()
+
+    /**
+     * Creates a LiveData with the value provided by the function, and stores both LiveData and
+     * function for later updates.
+     */
+    protected fun <T> toLiveData(valueProvider: () -> T?): LiveData<T> {
+        val liveData = MutableLiveData<T>()
+
+        // We know that the function generates values of the type expected by the MutableLiveData.
+        // Unfortunately, I don't know how to specify that for the map, so we use a cast.
+        // Another solution might be to add a type parameter to AbstractRepository and restrict each
+        // subclass to a single result type.
+        @Suppress("UNCHECKED_CAST")
+        liveDataMap.put(liveData as MutableLiveData<Any>, valueProvider)
+
+        valueProvider()?.let {
+            liveData.postValue(it)
+        }
+
+        return liveData
+    }
+
+    override fun update() {
+        Timber.d("Updating %d listeners.", liveDataMap.size)
+        // Update each LiveData using the provider function.
+        liveDataMap.forEach {
+            Timber.d("Updating note listener. Observers: %b", it.key.hasObservers())
+            it.key.postValue(it.value())
+        }
+    }
+}

--- a/app/src/main/java/de/theess/eisbaer/data/Database.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/Database.kt
@@ -7,6 +7,8 @@ import android.database.sqlite.SQLiteOpenHelper
 import android.net.Uri
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.preference.PreferenceManager
 import de.theess.eisbaer.BuildConfig
@@ -33,6 +35,10 @@ class Database(private val context: Context) {
          */
         private const val CHECK_INTERVAL: Long = 10 * 1000
     }
+
+    private var _status: MutableLiveData<String> = MutableLiveData("")
+    val status : LiveData<String>
+        get() = _status
 
     /**
      * The requery entity store. This is null if the database is closed.
@@ -103,6 +109,7 @@ class Database(private val context: Context) {
     @Synchronized
     private fun checkForUpdates() {
         Timber.d("Checking for updates.")
+        _status.postValue("")
 
         // Only check for updates while the app is in the foreground.
         val lifecycleState = ProcessLifecycleOwner.get().lifecycle.currentState
@@ -143,6 +150,8 @@ class Database(private val context: Context) {
 
         // Save hash of the external db.
         externalDatabaseHash = externalDbFile.hash()
+
+        _status.postValue("Database updated")
     }
 
     /**

--- a/app/src/main/java/de/theess/eisbaer/data/Database.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/Database.kt
@@ -6,6 +6,9 @@ import android.content.SharedPreferences
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.core.content.edit
+import androidx.core.database.getIntOrNull
 import androidx.preference.PreferenceManager
 import de.theess.eisbaer.BuildConfig
 import de.theess.eisbaer.EisbaerApplication
@@ -18,7 +21,7 @@ import java.io.FileOutputStream
 /**
  * Manages the requery data store.
  */
-class Database(val context: Context) {
+class Database(private val context: Context) {
 
     /**
      * Open the database once to initialize the android_metadata table.
@@ -38,20 +41,33 @@ class Database(val context: Context) {
     val entityStoreHolder: EntityStoreHolder = EntityStoreHolder(null)
 
     /**
+     * Size of the external database. This value is persisted to the preferences.
+     */
+    private var dbFileSize: Int = 0
+        set(value) {
+            field = value
+            PreferenceManager.getDefaultSharedPreferences(context).edit {
+                putInt(EisbaerApplication.PREF_DATABASE_FILE_SIZE, value)
+            }
+        }
+
+    /**
      * Resets the holder if the database uri pref changes.
      */
     private val preferenceListener: SharedPreferences.OnSharedPreferenceChangeListener =
-        SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
+        SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (key == EisbaerApplication.PREF_DATABASE_URI) synchronized(this) {
                 Timber.d("database uri pref changed")
-                initEntityStore()
+                updateDatabase()
             }
         }
 
     init {
-        PreferenceManager.getDefaultSharedPreferences(context)
-            .registerOnSharedPreferenceChangeListener(preferenceListener)
-        initEntityStore()
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        preferences.registerOnSharedPreferenceChangeListener(preferenceListener)
+        dbFileSize = preferences.getInt(EisbaerApplication.PREF_DATABASE_FILE_SIZE, 0)
+        updateDatabase()
+        if (!isOpen()) openDatabase()
     }
 
     /**
@@ -59,21 +75,62 @@ class Database(val context: Context) {
      * database is copied into the application data directory and then opened.
      */
     @Synchronized
-    private fun initEntityStore() {
+    private fun updateDatabase() {
         val uri = getExternalDatabaseUri(context)
         if (uri == null || !checkUriGrant(context, uri)) {
-            Timber.i("No database file")
+            Timber.i("No database file uri.")
             return
         }
 
+        if (context.getDatabasePath(DATABASE_NAME).exists()
+            && !externalDatabaseChanged(context, uri)
+        ) {
+            Timber.d("Database has not changed.")
+            return
+        }
+
+        Timber.d("Database changed.")
+
         copyDatabase(context, uri)
         DbInitializer(context, DATABASE_NAME).initDatabase()
+        openDatabase()
+    }
 
+    /**
+     * Opens the internal database.
+     */
+    private fun openDatabase() {
         val source = DatabaseSource(context, Models.DEFAULT, DATABASE_NAME, 1)
         if (BuildConfig.DEBUG) {
             source.setLoggingEnabled(true)
         }
-        entityStoreHolder.store = KotlinEntityDataStore<Any>(source.configuration)
+        entityStoreHolder.store = KotlinEntityDataStore(source.configuration)
+    }
+
+    private fun isOpen(): Boolean {
+        return entityStoreHolder.store != null
+    }
+
+    /**
+     * Checks whether the external database file has changed.
+     */
+    private fun externalDatabaseChanged(context: Context, uri: Uri): Boolean {
+        Timber.d("Checking database.")
+
+        val cursor = context.contentResolver.query(uri, null, null, null, null)
+
+        cursor?.use {
+            // moveToFirst() returns false if the cursor has 0 rows.
+            if (it.moveToFirst()) {
+                val size: Int = it.getIntOrNull(it.getColumnIndex(OpenableColumns.SIZE)) ?: 0
+                Timber.d("size: %d, previous size: %d", size, dbFileSize)
+                val changed = size != dbFileSize
+                dbFileSize = size
+                return changed
+            }
+        }
+
+        return true
     }
 
     /**
@@ -96,19 +153,25 @@ class Database(val context: Context) {
         Timber.d("copyDatabase done")
     }
 
+    /**
+     * Check whether we still can access the database uri.
+     */
     private fun checkUriGrant(context: Context, uri: Uri): Boolean {
-        try {
+        return try {
             context.contentResolver.takePersistableUriPermission(
                 uri,
                 Intent.FLAG_GRANT_READ_URI_PERMISSION
             )
-            return true
+            true
         } catch (e: Exception) {
             Timber.d(e, "Failed to get uri grant.")
-            return false
+            false
         }
     }
 
+    /**
+     * Gets the URI to the external database file from the preferences.
+     */
     private fun getExternalDatabaseUri(context: Context): Uri? {
         return PreferenceManager.getDefaultSharedPreferences(context)
             .getString(EisbaerApplication.PREF_DATABASE_URI, null)
@@ -116,6 +179,9 @@ class Database(val context: Context) {
     }
 
     companion object {
+        /**
+         * Name of the internal database.
+         */
         private const val DATABASE_NAME = "note_db"
     }
 }

--- a/app/src/main/java/de/theess/eisbaer/data/DatabaseListener.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/DatabaseListener.kt
@@ -1,0 +1,8 @@
+package de.theess.eisbaer.data
+
+/**
+ * Listen for database changes.
+ */
+interface DatabaseListener {
+    fun update()
+}

--- a/app/src/main/java/de/theess/eisbaer/data/DatabaseListener.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/DatabaseListener.kt
@@ -4,5 +4,8 @@ package de.theess.eisbaer.data
  * Listen for database changes.
  */
 interface DatabaseListener {
+    /**
+     * This method is called when the database was updated.
+     */
     fun update()
 }

--- a/app/src/main/java/de/theess/eisbaer/data/EntityStoreHolder.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/EntityStoreHolder.kt
@@ -1,9 +1,0 @@
-package de.theess.eisbaer.data
-
-import io.requery.sql.KotlinEntityDataStore
-import timber.log.Timber
-
-class EntityStoreHolder(store: KotlinEntityDataStore<Any>?) {
-    @Volatile
-    var store = store.also { Timber.d("store holder changed: $it") }
-}

--- a/app/src/main/java/de/theess/eisbaer/data/StorageFile.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/StorageFile.kt
@@ -3,6 +3,7 @@ package de.theess.eisbaer.data
 import android.content.ContentResolver
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.provider.DocumentsContract
 import android.provider.OpenableColumns
 import androidx.core.database.getIntOrNull
@@ -13,10 +14,10 @@ import java.io.InputStream
 /**
  * A file from the Storage Access Framework.
  */
-class StorageFile(val uri: Uri, private val contentResolver: ContentResolver) {
+class StorageFile(private val uri: Uri, private val contentResolver: ContentResolver) {
 
-    var size: Int = 0
-    var lastModified: Long = 0
+    private var size: Int = 0
+    private var lastModified: Long = 0
 
     init {
         readMetadata()
@@ -70,4 +71,14 @@ class StorageFile(val uri: Uri, private val contentResolver: ContentResolver) {
         return contentResolver.openInputStream(uri)!!
     }
 
+    /**
+     * Tell the content provider to refresh (e.g. download) the file. Works only on Android 8+.
+     */
+    fun refresh() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            contentResolver.refresh(uri, null, null)
+        } else {
+            Timber.i("Refresh not supported on API level %d.", Build.VERSION.SDK_INT)
+        }
+    }
 }

--- a/app/src/main/java/de/theess/eisbaer/data/StorageFile.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/StorageFile.kt
@@ -1,0 +1,73 @@
+package de.theess.eisbaer.data
+
+import android.content.ContentResolver
+import android.content.Intent
+import android.net.Uri
+import android.provider.DocumentsContract
+import android.provider.OpenableColumns
+import androidx.core.database.getIntOrNull
+import androidx.core.database.getLongOrNull
+import timber.log.Timber
+import java.io.InputStream
+
+/**
+ * A file from the Storage Access Framework.
+ */
+class StorageFile(val uri: Uri, private val contentResolver: ContentResolver) {
+
+    var size: Int = 0
+    var lastModified: Long = 0
+
+    init {
+        readMetadata()
+    }
+
+    private fun readMetadata() {
+        Timber.d("Reading metadata")
+
+        val cursor = contentResolver.query(uri, null, null, null, null)
+
+        cursor?.use {
+            // moveToFirst() returns false if the cursor has 0 rows.
+            if (!it.moveToFirst()) {
+                return
+            }
+
+            size = it.getIntOrNull(it.getColumnIndex(OpenableColumns.SIZE)) ?: 0
+            lastModified =
+                it.getLongOrNull(it.getColumnIndex(DocumentsContract.Document.COLUMN_LAST_MODIFIED))
+                    ?: 0
+        }
+
+    }
+
+    override fun toString(): String {
+        val hash = hash()
+        return "StorageFile($hash)"
+    }
+
+    /**
+     * Returns a hash of the file based on the metadata.
+     */
+    fun hash() : String {
+        return "size=$size, lastModified=$lastModified, uri=$uri"
+    }
+
+    /**
+     * Check whether we still can access the database uri.
+     */
+    fun checkUriGrant(): Boolean {
+        return try {
+            contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            true
+        } catch (e: Exception) {
+            Timber.d(e, "Failed to get uri grant.")
+            false
+        }
+    }
+
+    fun openInputStream(): InputStream {
+        return contentResolver.openInputStream(uri)!!
+    }
+
+}

--- a/app/src/main/java/de/theess/eisbaer/data/TagRepository.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/TagRepository.kt
@@ -1,22 +1,21 @@
 package de.theess.eisbaer.data
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import de.theess.eisbaer.EisbaerApplication
 import io.requery.kotlin.asc
 import timber.log.Timber
 
-class TagRepository private constructor(private val database: Database) {
+class TagRepository(private val database: Database) : AbstractRepository(database) {
 
     fun getAll(): LiveData<List<Tag>> {
         Timber.d("getAll")
-        return database.store
-            ?.run {
-                select(Tag::class)
-                    .orderBy(Tag::title.asc()).limit(QUERY_LIMIT)
-            }
-            ?.let { MutableLiveData(it.get().toList()) }
-            ?: MutableLiveData()
+        return toLiveData {
+            database.store
+                ?.run {
+                    select(Tag::class)
+                        .orderBy(Tag::title.asc()).limit(QUERY_LIMIT)
+                }?.get()?.toList()
+        }
     }
 
     companion object {

--- a/app/src/main/java/de/theess/eisbaer/data/TagRepository.kt
+++ b/app/src/main/java/de/theess/eisbaer/data/TagRepository.kt
@@ -6,11 +6,11 @@ import de.theess.eisbaer.EisbaerApplication
 import io.requery.kotlin.asc
 import timber.log.Timber
 
-class TagRepository private constructor(private val holder: EntityStoreHolder) {
+class TagRepository private constructor(private val database: Database) {
 
     fun getAll(): LiveData<List<Tag>> {
         Timber.d("getAll")
-        return holder.store
+        return database.store
             ?.run {
                 select(Tag::class)
                     .orderBy(Tag::title.asc()).limit(QUERY_LIMIT)
@@ -28,7 +28,7 @@ class TagRepository private constructor(private val holder: EntityStoreHolder) {
 
         fun getInstance(application: EisbaerApplication) =
             instance ?: synchronized(this) {
-                instance ?: TagRepository(application.database.entityStoreHolder).also {
+                instance ?: TagRepository(application.database).also {
                     instance = it
                 }
             }

--- a/app/src/main/java/de/theess/eisbaer/ui/search/SearchFragment.kt
+++ b/app/src/main/java/de/theess/eisbaer/ui/search/SearchFragment.kt
@@ -51,6 +51,12 @@ class SearchFragment : Fragment(), SearchView.OnQueryTextListener {
 
         // Show current query in the search view.
         searchView.setQuery(viewModel.query.value, true)
+
+        // handle swipe-to-refresh
+        swiperefresh.setOnRefreshListener {
+            viewModel.refresh()
+            swiperefresh.isRefreshing = false
+        }
     }
 
     override fun onCreateView(

--- a/app/src/main/java/de/theess/eisbaer/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/de/theess/eisbaer/ui/search/SearchViewModel.kt
@@ -36,4 +36,11 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
         }
         _query.value = input
     }
+
+    /**
+     * Tell the content provider to refresh (e.g. download) the database file. Works only on Android 8+.
+     */
+    fun refresh() {
+        getApplication<EisbaerApplication>().database.refresh()
+    }
 }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/swiperefresh"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -32,4 +33,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
Every 10 seconds, Eisbär checks the database file for changes, i.e., different size or modification date. If changes are detected, the external database file is copied into the private app data directory and the internal database is reopened. Changes to the database or propagated to the view using LiveData wrappers.